### PR TITLE
Fix Xcode selection in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Select Xcode
+        run: ls -l /Applications && sudo xcode-select -s /Applications/Xcode_26.app
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Add explicit Xcode version selection step to the release workflow to ensure builds use the correct Xcode installation. Lists available Xcode installations and selects Xcode 26 before running the build process.
