### PR TITLE
Add Fastlane automation and improve multi-platform support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release Build and Upload
 
 on:
-  # push:
-  #   branches: [fastlane]
+  push:
+    branches: [fastlane]
   # Trigger when CI workflow completes successfully
   workflow_run:
     workflows: ["CI"]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -49,6 +49,7 @@ platform :ios do
       scheme: 'LiveClock',
       destination: 'generic/platform=iOS',
       output_directory: './build/release/ios',
+      output_name: 'LiveClock-iOS',
       sdk: 'iphoneos'
     )
   end
@@ -59,7 +60,7 @@ platform :ios do
 
     pilot(
       skip_waiting_for_build_processing: true,
-      ipa: './build/release/ios/LiveClock.ipa'
+      ipa: './build/release/ios/LiveClock-iOS.ipa'
     )
   end
 
@@ -147,6 +148,7 @@ platform :mac do
       scheme: 'LiveClock',
       destination: 'generic/platform=macOS',
       output_directory: './build/release/mac',
+      output_name: 'LiveClock-macOS',
       sdk: 'macosx'
     )
   end
@@ -159,7 +161,7 @@ platform :mac do
     upload_to_app_store(
       app_identifier: 'io.ngs.LiveClock',
       platform: 'osx',
-      pkg: './build/release/mac/LiveClock.pkg',
+      pkg: './build/release/mac/LiveClock-macOS.pkg',
       skip_screenshots: true,
       skip_metadata: true,
       force: true,
@@ -229,6 +231,7 @@ platform :visionos do
       scheme: 'LiveClock',
       destination: 'generic/platform=visionOS',
       output_directory: './build/release/visionos',
+      output_name: 'LiveClock-visionOS',
       sdk: 'iphoneos'
     )
   end
@@ -239,7 +242,7 @@ platform :visionos do
 
     pilot(
       skip_waiting_for_build_processing: true,
-      ipa: './build/release/visionos/LiveClock.ipa'
+      ipa: './build/release/visionos/LiveClock-visionOS.ipa'
     )
   end
 


### PR DESCRIPTION
This pull request updates the release workflow and Fastlane configuration to standardize output file naming for iOS, macOS, and visionOS builds, ensuring consistency between build outputs and the files uploaded to App Store Connect/TestFlight. It also enables the release workflow to trigger on pushes to the `fastlane` branch.

**Release workflow improvements:**

* Enabled the release workflow to trigger on pushes to the `fastlane` branch in `.github/workflows/release.yml`.

**Fastlane build and upload consistency:**

* Set explicit `output_name` values for `gym` actions for iOS, macOS, and visionOS builds in `Fastfile`, resulting in platform-specific file names (`LiveClock-iOS`, `LiveClock-macOS`, `LiveClock-visionOS`). [[1]](diffhunk://#diff-dff4b99d4e651ab9d7597876ec8dbe92aa934e42c0fb55f4aadd6c106fc96688R52) [[2]](diffhunk://#diff-dff4b99d4e651ab9d7597876ec8dbe92aa934e42c0fb55f4aadd6c106fc96688R151) [[3]](diffhunk://#diff-dff4b99d4e651ab9d7597876ec8dbe92aa934e42c0fb55f4aadd6c106fc96688R234)
* Updated paths for `ipa` and `pkg` files in `pilot` and `upload_to_app_store` actions to match the new output file names, ensuring correct files are uploaded for each platform. [[1]](diffhunk://#diff-dff4b99d4e651ab9d7597876ec8dbe92aa934e42c0fb55f4aadd6c106fc96688L62-R63) [[2]](diffhunk://#diff-dff4b99d4e651ab9d7597876ec8dbe92aa934e42c0fb55f4aadd6c106fc96688L162-R164) [[3]](diffhunk://#diff-dff4b99d4e651ab9d7597876ec8dbe92aa934e42c0fb55f4aadd6c106fc96688L242-R245)