### PR TITLE
Add platform-specific build number suffixes for CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Generate Xcode project and workspace
         run: tuist generate --no-open
         env:
-          TUIST_BUILD_NUMBER: "${{ github.run_id }}.${{ matrix.buildNumberSuffix }}"
+          TUIST_BUILD_NUMBER: "${{ github.run_id }}${{ matrix.buildNumberSuffix }}"
 
       - name: Build ${{ matrix.platform }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,13 @@ jobs:
         include:
           - platform: iOS
             destination: "platform=iOS Simulator,name=iPhone 16 Pro Max,OS=18.5"
+            buildNumberSuffix: ".1"
           - platform: macOS
             destination: "platform=macOS"
+            buildNumberSuffix: ".2"
           - platform: visionOS
             destination: "platform=visionOS Simulator,name=Apple Vision Pro,OS=2.5"
+            buildNumberSuffix: ".3"
 
     steps:
       - uses: actions/checkout@v5
@@ -34,7 +37,7 @@ jobs:
       - name: Generate Xcode project and workspace
         run: tuist generate --no-open
         env:
-          TUIST_RUN_ID: ${{ github.run_id }}
+          TUIST_BUILD_NUMBER: ${{ github.run_id }}${{ matrix.buildNumberSuffix }}
 
       - name: Build and Test (${{ matrix.platform }})
         run: |
@@ -96,7 +99,7 @@ jobs:
       - name: Generate Xcode project and workspace
         run: tuist generate --no-open
         env:
-          TUIST_RUN_ID: ${{ github.run_id }}
+          TUIST_BUILD_NUMBER: "${{ github.run_id }}.0"
 
       - name: periphery scan
         run: periphery scan --strict
@@ -125,10 +128,13 @@ jobs:
         include:
           - platform: iOS
             destination: "generic/platform=iOS Simulator"
+            buildNumberSuffix: ".1"
           - platform: macOS
             destination: "platform=macOS"
+            buildNumberSuffix: ".2"
           - platform: visionOS
             destination: "generic/platform=visionOS Simulator"
+            buildNumberSuffix: ".3"
 
     steps:
       - uses: actions/checkout@v5
@@ -144,7 +150,7 @@ jobs:
       - name: Generate Xcode project and workspace
         run: tuist generate --no-open
         env:
-          TUIST_RUN_ID: ${{ github.run_id }}
+          TUIST_BUILD_NUMBER: "${{ github.run_id }}.${{ matrix.buildNumberSuffix }}"
 
       - name: Build ${{ matrix.platform }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,9 +166,20 @@ jobs:
           brew install --formula tuist
 
       - name: Generate Xcode project and workspace
-        run: tuist generate --no-open
-        env:
-          TUIST_RUN_ID: ${{ github.run_id }}
+        run: |
+          case "${{ matrix.platform }}" in
+            ios)
+              export TUIST_BUILD_NUMBER="${{ github.run_id }}.1"
+              ;;
+            mac)
+              export TUIST_BUILD_NUMBER="${{ github.run_id }}.2"
+              ;;
+            visionos)
+              export TUIST_BUILD_NUMBER="${{ github.run_id }}.3"
+              ;;
+          esac
+          echo "Using build number: $TUIST_BUILD_NUMBER"
+          tuist generate --no-open
 
       - name: Get version info
         id: version

--- a/Project.swift
+++ b/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let version = "1.0.0"
 let copyright = "© LittleApps Inc. All Rights Reserved."
 
-let actionRunId = Environment.runId.getString(default: "0")
+let buildNumber = Environment.buildNumber.getString(default: "0")
 
 let project = Project(
     name: "LiveClock",
@@ -15,7 +15,7 @@ let project = Project(
         base: [
             "INFOPLIST_KEY_LSApplicationCategoryType": .string("public.app-category.productivity"),
             "INFOPLIST_KEY_CFBundleIconFile": .string("AppIcon"),
-            "CURRENT_PROJECT_VERSION": .string(actionRunId),
+            "CURRENT_PROJECT_VERSION": .string(buildNumber),
             "MARKETING_VERSION": .string(version),
             "DEVELOPMENT_TEAM": .string("3Y8APYUG2G"),
             "SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD": "NO"

--- a/Project.swift
+++ b/Project.swift
@@ -38,7 +38,10 @@ let project = Project(
                 "NSHumanReadableCopyright": .string(copyright),
                 "LSApplicationCategoryType": .string("public.app-category.productivity"),
                 "UIViewControllerBasedStatusBarAppearance": .boolean(false),
-                "UILaunchStoryboardName": .string(""),
+                "UILaunchScreen": [
+                    "UIColorName": "LaunchScreenBackground",
+                    "UIImageRespectsSafeAreaInsets": true
+                ],
                 "UIStatusBarHidden": .boolean(true)
             ]),
             sources: ["Sources/App/**"],

--- a/Sources/Resources/Assets.xcassets/LaunchScreenBackground.colorset/Contents.json
+++ b/Sources/Resources/Assets.xcassets/LaunchScreenBackground.colorset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "platform" : "ios",
+        "reference" : "systemBackgroundColor"
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "platform" : "ios",
+        "reference" : "systemBackgroundColor"
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,20 +1,5 @@
 # frozen_string_literal: true
 
-# This file contains the fastlane.tools configuration
-# You can find the documentation at https://docs.fastlane.tools
-#
-# For a list of all available actions, check out
-#
-#     https://docs.fastlane.tools/actions
-#
-# For a list of all available plugins, check out
-#
-#     https://docs.fastlane.tools/plugins/available-plugins
-#
-
-# Uncomment the line if you want fastlane to automatically update itself
-# update_fastlane
-#
 default_platform(:ios)
 
 platform :ios do
@@ -226,13 +211,17 @@ platform :visionos do
       build_configurations: %w[Release],
       path: 'LiveClock.xcodeproj'
     )
+
+    # Load monkey patches
+    require_relative 'patches/gym_module_patch'
+
     build_app(
       export_method: 'app-store',
       scheme: 'LiveClock',
       destination: 'generic/platform=visionOS',
       output_directory: './build/release/visionos',
       output_name: 'LiveClock-visionOS',
-      sdk: 'iphoneos'
+      sdk: 'xros'
     )
   end
 

--- a/fastlane/patches/gym_module_patch.rb
+++ b/fastlane/patches/gym_module_patch.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Monkey patch for Gym::Module.building_multiplatform_for_ios? method
+# This patch modifies the method to correctly handle xros SDK
+
+require 'gym'
+
+# Thank you Gym
+module Gym
+  class << self
+    # Override the building_multiplatform_for_ios? method
+    alias original_building_multiplatform_for_ios? building_multiplatform_for_ios? if method_defined?(:building_multiplatform_for_ios?)
+
+    def building_multiplatform_for_ios?
+      # Modified condition from line 62 of gym/lib/gym/module.rb
+      Gym.project.multiplatform? && Gym.project.ios? && %w[xros iphoneos iphonesimulator].include?(Gym.config[:sdk])
+    end
+  end
+end
+
+puts '[Gym Patch] Applied monkey patch for building_multiplatform_for_ios? to include xros SDK'


### PR DESCRIPTION
- Add buildNumberSuffix to CI workflow matrix for iOS (.1), macOS (.2), visionOS (.3)
- Rename TUIST_RUN_ID to TUIST_BUILD_NUMBER for clarity
- Update Project.swift to use buildNumber instead of actionRunId
