### PR TITLE
Add snapshot testing infrastructure for iOS app screenshots

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -76,6 +76,17 @@ let project = Project(
                 .package(product: "LiveClockCore"),
                 .package(product: "LiveClockUI")
             ]
+        ),
+        .target(
+            name: "LiveClockSnapshotTests",
+            destinations: [.iPhone, .iPad],
+            product: .uiTests,
+            bundleId: "io.ngs.LiveClockSnapshotTests",
+            deploymentTargets: .iOS("26.0"),
+            sources: ["Tests/LiveClockSnapshotTests/**"],
+            dependencies: [
+                .target(name: "LiveClock")
+            ]
         )
     ],
     schemes: [
@@ -86,6 +97,16 @@ let project = Project(
                 ["LiveClockTests"],
                 configuration: .debug,
                 options: .options(coverage: true)
+            ),
+            runAction: .runAction(configuration: .debug)
+        ),
+        .scheme(
+            name: "LiveClockSnapshot",
+            buildAction: .buildAction(targets: ["LiveClock"]),
+            testAction: .targets(
+                ["LiveClockSnapshotTests"],
+                configuration: .debug,
+                options: .options(coverage: false)
             ),
             runAction: .runAction(configuration: .debug)
         )

--- a/Sources/UI/Screens/SplitViewScreen.swift
+++ b/Sources/UI/Screens/SplitViewScreen.swift
@@ -32,7 +32,7 @@ struct SplitViewScreen: View {
                         ToolbarItem(placement: .topBarTrailing) {
                             Button("Back", systemImage: "chevron.right") {
                                 preferredCompactColumn = .detail
-                            }
+                            }.accessibility(identifier: "BackButton")
                         }
                     }
 #endif
@@ -93,6 +93,7 @@ private struct SidebarLapsView: View {
         } else {
             LapListView()
                 .navigationTitle(String(localized: "Laps", bundle: .module))
+                .accessibility(identifier: "LapListView")
         }
     }
 }

--- a/Sources/UI/Views/ControlsView.swift
+++ b/Sources/UI/Views/ControlsView.swift
@@ -23,6 +23,7 @@ struct ControlsView: View {
                     .controlSize(.large)
                     .keyboardShortcut("r")
                     .accessibilityHint(String(localized: "Reset the stopwatch to zero", bundle: .module))
+                    .accessibility(identifier: "ResetButton")
                 Button(action: {
                     app.stopwatch.start()
                     if app.preferences.enableHaptics || app.preferences.enableSounds {
@@ -36,6 +37,7 @@ struct ControlsView: View {
                     .controlSize(.large)
                     .keyboardShortcut(.space)
                     .accessibilityHint(String(localized: "Resume the stopwatch", bundle: .module))
+                    .accessibility(identifier: "ResumeButton")
             } else {
                 Button(action: {
                     app.stopwatch.lap()
@@ -51,6 +53,7 @@ struct ControlsView: View {
                     .controlSize(.large)
                     .keyboardShortcut("l")
                     .accessibilityHint(String(localized: "Record a lap time", bundle: .module))
+                    .accessibility(identifier: "LapButton")
                 if app.stopwatchState == .running {
                     Button(role: .destructive, action: {
                         app.stopwatch.pause()
@@ -65,6 +68,7 @@ struct ControlsView: View {
                     .controlSize(.large)
                     .keyboardShortcut(.space)
                     .accessibilityHint(String(localized: "Pause the stopwatch", bundle: .module))
+                    .accessibility(identifier: "StopButton")
                 } else {
                     Button(action: {
                         app.stopwatch.start()
@@ -79,6 +83,7 @@ struct ControlsView: View {
                         .controlSize(.large)
                         .keyboardShortcut(.space)
                         .accessibilityHint(String(localized: "Start the stopwatch", bundle: .module))
+                        .accessibility(identifier: "StartButton")
                 }
             }
         }

--- a/Tests/LiveClockSnapshotTests/LiveClockSnapshotTests.swift
+++ b/Tests/LiveClockSnapshotTests/LiveClockSnapshotTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+
+final class LiveClockSnapshotTests: XCTestCase {
+    private let nonexistencePredicate = NSPredicate(format: "exists == false")
+    private let existencePredicate = NSPredicate(format: "exists == true")
+
+    @MainActor
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+
+        let app = XCUIApplication()
+        setupSnapshot(app)
+        app.launch()
+    }
+
+    @MainActor
+    func testTakeSnapshots() throws {
+        XCUIDevice.shared.orientation = .portrait
+
+        let app = XCUIApplication()
+
+        expectation(
+            for: existencePredicate,
+            evaluatedWith: app.buttons["StartButton"],
+            handler: nil)
+
+        waitForExpectations(timeout: 10, handler: nil)
+
+        snapshot("01_MainScreen_Stopped")
+
+        app.buttons["StartButton"].tap()
+
+        sleep(2)
+
+        for _ in repeatElement((), count: 10) {
+            app.buttons["LapButton"].tap()
+            sleep(1)
+        }
+
+        snapshot("02_MainScreen_Started")
+
+        app.navigationBars.firstMatch.buttons.firstMatch.tap()
+
+        sleep(1)
+
+        snapshot("03_LapList")
+
+        app.navigationBars.firstMatch.buttons.firstMatch.tap()
+
+        sleep(1)
+
+        XCUIDevice.shared.orientation = .landscapeLeft
+
+        sleep(1)
+
+        snapshot("04_MainScreen_Landscape")
+    }
+}

--- a/Tests/LiveClockSnapshotTests/SnapshotHelper.swift
+++ b/Tests/LiveClockSnapshotTests/SnapshotHelper.swift
@@ -1,0 +1,311 @@
+//
+//  SnapshotHelper.swift
+//  Example
+//
+//  Created by Felix Krause on 10/8/15.
+//
+
+// -----------------------------------------------------
+// IMPORTANT: When modifying this file, make sure to
+//            increment the version number at the very
+//            bottom of the file to notify users about
+//            the new SnapshotHelper.swift
+// -----------------------------------------------------
+
+import Foundation
+import XCTest
+
+@MainActor
+func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
+    Snapshot.setupSnapshot(app, waitForAnimations: waitForAnimations)
+}
+
+@MainActor
+func snapshot(_ name: String, waitForLoadingIndicator: Bool) {
+    if waitForLoadingIndicator {
+        Snapshot.snapshot(name)
+    } else {
+        Snapshot.snapshot(name, timeWaitingForIdle: 0)
+    }
+}
+
+/// - Parameters:
+///   - name: The name of the snapshot
+///   - timeout: Amount of seconds to wait until the network loading indicator disappears. Pass `0` if you don't want to wait.
+@MainActor
+func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+    Snapshot.snapshot(name, timeWaitingForIdle: timeout)
+}
+
+enum SnapshotError: Error, CustomDebugStringConvertible {
+    case cannotFindSimulatorHomeDirectory
+    case cannotRunOnPhysicalDevice
+
+    var debugDescription: String {
+        switch self {
+        case .cannotFindSimulatorHomeDirectory:
+            return "Couldn't find simulator home location. Please, check SIMULATOR_HOST_HOME env variable."
+        case .cannotRunOnPhysicalDevice:
+            return "Can't use Snapshot on a physical device."
+        }
+    }
+}
+
+@objcMembers
+@MainActor
+open class Snapshot: NSObject {
+    static var app: XCUIApplication?
+    static var waitForAnimations = true
+    static var cacheDirectory: URL?
+    static var screenshotsDirectory: URL? {
+        return cacheDirectory?.appendingPathComponent("screenshots", isDirectory: true)
+    }
+    static var deviceLanguage = ""
+    static var currentLocale = ""
+
+    open class func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
+        Snapshot.app = app
+        Snapshot.waitForAnimations = waitForAnimations
+
+        do {
+            let cacheDir = try getCacheDirectory()
+            Snapshot.cacheDirectory = cacheDir
+            setLanguage(app)
+            setLocale(app)
+            setLaunchArguments(app)
+        } catch {
+            NSLog(error.localizedDescription)
+        }
+    }
+
+    class func setLanguage(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
+            return
+        }
+
+        let path = cacheDirectory.appendingPathComponent("language.txt")
+
+        do {
+            let trimCharacterSet = CharacterSet.whitespacesAndNewlines
+            deviceLanguage = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
+            app.launchArguments += ["-AppleLanguages", "(\(deviceLanguage))"]
+        } catch {
+            NSLog("Couldn't detect/set language...")
+        }
+    }
+
+    class func setLocale(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
+            return
+        }
+
+        let path = cacheDirectory.appendingPathComponent("locale.txt")
+
+        do {
+            let trimCharacterSet = CharacterSet.whitespacesAndNewlines
+            currentLocale = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
+        } catch {
+            NSLog("Couldn't detect/set locale...")
+        }
+
+        if currentLocale.isEmpty && !deviceLanguage.isEmpty {
+            currentLocale = Locale(identifier: deviceLanguage).identifier
+        }
+
+        if !currentLocale.isEmpty {
+            app.launchArguments += ["-AppleLocale", "\"\(currentLocale)\""]
+        }
+    }
+
+    class func setLaunchArguments(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
+            return
+        }
+
+        let path = cacheDirectory.appendingPathComponent("snapshot-launch_arguments.txt")
+        app.launchArguments += ["-FASTLANE_SNAPSHOT", "YES", "-ui_testing"]
+
+        do {
+            let launchArguments = try String(contentsOf: path, encoding: String.Encoding.utf8)
+            let regex = try NSRegularExpression(pattern: "(\\\".+?\\\"|\\S+)", options: [])
+            let matches = regex.matches(in: launchArguments, options: [], range: NSRange(location: 0, length: launchArguments.count))
+            let results = matches.map { result -> String in
+                (launchArguments as NSString).substring(with: result.range)
+            }
+            app.launchArguments += results
+        } catch {
+            NSLog("Couldn't detect/set launch_arguments...")
+        }
+    }
+
+    open class func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+        if timeout > 0 {
+            waitForLoadingIndicatorToDisappear(within: timeout)
+        }
+
+        NSLog("snapshot: \(name)") // more information about this, check out https://docs.fastlane.tools/actions/snapshot/#how-does-it-work
+
+        if Snapshot.waitForAnimations {
+            sleep(1) // Waiting for the animation to be finished (kind of)
+        }
+
+        #if os(OSX)
+            guard let app = self.app else {
+                NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+                return
+            }
+
+            app.typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
+        #else
+
+            guard self.app != nil else {
+                NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+                return
+            }
+
+            let screenshot = XCUIScreen.main.screenshot()
+            #if os(iOS) && !targetEnvironment(macCatalyst)
+            let image = XCUIDevice.shared.orientation.isLandscape ? fixLandscapeOrientation(image: screenshot.image) : screenshot.image
+            #else
+            let image = screenshot.image
+            #endif
+
+            guard var simulator = ProcessInfo().environment["SIMULATOR_DEVICE_NAME"], let screenshotsDir = screenshotsDirectory else { return }
+
+            do {
+                // The simulator name contains "Clone X of " inside the screenshot file when running parallelized UI Tests on concurrent devices
+                let regex = try NSRegularExpression(pattern: "Clone [0-9]+ of ")
+                let range = NSRange(location: 0, length: simulator.count)
+                simulator = regex.stringByReplacingMatches(in: simulator, range: range, withTemplate: "")
+
+                let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")
+                #if swift(<5.0)
+                    try UIImagePNGRepresentation(image)?.write(to: path, options: .atomic)
+                #else
+                    try image.pngData()?.write(to: path, options: .atomic)
+                #endif
+            } catch {
+                NSLog("Problem writing screenshot: \(name) to \(screenshotsDir)/\(simulator)-\(name).png")
+                NSLog(error.localizedDescription)
+            }
+        #endif
+    }
+
+    class func fixLandscapeOrientation(image: UIImage) -> UIImage {
+        #if os(watchOS)
+            return image
+        #else
+            if #available(iOS 10.0, *) {
+                let format = UIGraphicsImageRendererFormat()
+                format.scale = image.scale
+                let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
+                return renderer.image { _ in
+                    image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
+                }
+            } else {
+                return image
+            }
+        #endif
+    }
+
+    class func waitForLoadingIndicatorToDisappear(within timeout: TimeInterval) {
+        #if os(tvOS)
+            return
+        #endif
+
+        guard let app = self.app else {
+            NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+            return
+        }
+
+        let networkLoadingIndicator = app.otherElements.deviceStatusBars.networkLoadingIndicators.element
+        let networkLoadingIndicatorDisappeared = XCTNSPredicateExpectation(predicate: NSPredicate(format: "exists == false"), object: networkLoadingIndicator)
+        _ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
+    }
+
+    class func getCacheDirectory() throws -> URL {
+        let cachePath = "Library/Caches/tools.fastlane"
+        // on OSX config is stored in /Users/<username>/Library
+        // and on iOS/tvOS/WatchOS it's in simulator's home dir
+        #if os(OSX)
+            let homeDir = URL(fileURLWithPath: NSHomeDirectory())
+            return homeDir.appendingPathComponent(cachePath)
+        #elseif arch(i386) || arch(x86_64) || arch(arm64)
+            guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
+                throw SnapshotError.cannotFindSimulatorHomeDirectory
+            }
+            let homeDir = URL(fileURLWithPath: simulatorHostHome)
+            return homeDir.appendingPathComponent(cachePath)
+        #else
+            throw SnapshotError.cannotRunOnPhysicalDevice
+        #endif
+    }
+}
+
+private extension XCUIElementAttributes {
+    var isNetworkLoadingIndicator: Bool {
+        if hasAllowListedIdentifier { return false }
+
+        let hasOldLoadingIndicatorSize = frame.size == CGSize(width: 10, height: 20)
+        let hasNewLoadingIndicatorSize = frame.size.width.isBetween(46, and: 47) && frame.size.height.isBetween(2, and: 3)
+
+        return hasOldLoadingIndicatorSize || hasNewLoadingIndicatorSize
+    }
+
+    var hasAllowListedIdentifier: Bool {
+        let allowListedIdentifiers = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
+
+        return allowListedIdentifiers.contains(identifier)
+    }
+
+    func isStatusBar(_ deviceWidth: CGFloat) -> Bool {
+        if elementType == .statusBar { return true }
+        guard frame.origin == .zero else { return false }
+
+        let oldStatusBarSize = CGSize(width: deviceWidth, height: 20)
+        let newStatusBarSize = CGSize(width: deviceWidth, height: 44)
+
+        return [oldStatusBarSize, newStatusBarSize].contains(frame.size)
+    }
+}
+
+private extension XCUIElementQuery {
+    var networkLoadingIndicators: XCUIElementQuery {
+        let isNetworkLoadingIndicator = NSPredicate { evaluatedObject, _ in
+            guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+            return element.isNetworkLoadingIndicator
+        }
+
+        return self.containing(isNetworkLoadingIndicator)
+    }
+
+    @MainActor var deviceStatusBars: XCUIElementQuery {
+        guard let app = Snapshot.app else {
+            fatalError("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+        }
+
+        let deviceWidth = app.windows.firstMatch.frame.width
+
+        let isStatusBar = NSPredicate { evaluatedObject, _ in
+            guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+            return element.isStatusBar(deviceWidth)
+        }
+
+        return self.containing(isStatusBar)
+    }
+}
+
+private extension CGFloat {
+    func isBetween(_ numberA: CGFloat, and numberB: CGFloat) -> Bool {
+        return numberA...numberB ~= self
+    }
+}
+
+// Please don't remove the lines below
+// They are used to detect outdated configuration files
+// SnapshotHelperVersion [1.30]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -64,6 +64,14 @@ platform :ios do
     )
   end
 
+  desc 'Take screenshots using snapshot'
+  lane :take_screenshots do
+    require_relative 'patches/snapshot_mac_detection_patch'
+    require_relative 'patches/device_manager_patch'
+
+    snapshot
+  end
+
   desc 'Update App Store screenshots'
   lane :deliver_screenshots do
     setup_app_store_connect_api_key

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -66,6 +66,14 @@ Publish app to App Store
 
 Update App Store metadata
 
+### ios take_screenshots
+
+```sh
+[bundle exec] fastlane ios take_screenshots
+```
+
+Take screenshots using snapshot
+
 ### ios deliver_screenshots
 
 ```sh

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+devices([
+          'iPhone 14 Plus',
+          'iPad Pro (12.9-inch) (6th generation)'
+        ])
+
+ios_version('26.0')
+
+languages([
+            'en-US',
+            'ja'
+          ])
+
+# The name of the scheme which contains the UI Tests
+scheme('LiveClockSnapshot')
+
+output_directory('./fastlane/screenshots/ios')
+
+clear_previous_screenshots(true)
+
+# Remove the '#' to set the status bar to 9:41 AM, and show full battery and reception. See also override_status_bar_arguments for custom options.
+# override_status_bar(true)
+
+# Arguments to pass to the app on launch. See https://docs.fastlane.tools/actions/snapshot/#launch-arguments
+# launch_arguments(["-favColor red"])
+
+# For more information about all available options run
+# fastlane action snapshot

--- a/fastlane/patches/device_manager_patch.rb
+++ b/fastlane/patches/device_manager_patch.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Monkey patch for fastlane 2.228.0 to fix iOS 26.0 simulator detection issue
+
+require 'open3'
+
+module FastlaneCore
+  class DeviceManager
+    class << self
+      # Override the problematic method to handle nil case properly
+      alias_method :original_latest_simulator_version_for_device, :latest_simulator_version_for_device if method_defined?(:latest_simulator_version_for_device)
+
+      def latest_simulator_version_for_device(device)
+        matching_simulators = simulators.select { |s| s.name == device }
+
+        # Return nil if no matching simulators found
+        return nil if matching_simulators.empty?
+
+        # Sort by OS version and return the latest
+        matching_simulators
+          .sort_by { |s| Gem::Version.create(s.os_version) }
+          .last
+          &.os_version
+      end
+    end
+  end
+end
+
+# Patch loaded successfully

--- a/fastlane/patches/snapshot_mac_detection_patch.rb
+++ b/fastlane/patches/snapshot_mac_detection_patch.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Monkey patch to prevent snapshot from detecting this as a Mac-only project
+# This allows iOS device screenshots to work properly with iOS 26.0
+
+module FastlaneCore
+  class Project
+    # Override mac? to always return false for snapshot
+    alias_method :original_mac?, :mac? if method_defined?(:mac?)
+
+    def mac?
+      # Check if we're being called from snapshot context
+      caller_locations = caller
+      if caller_locations.any? { |loc| loc.to_s.include?('snapshot') }
+        # Return false when called from snapshot to prevent device override
+        return false
+      end
+
+      # Return original value for other contexts
+      original_mac?
+    end
+  end
+end
+
+# Patch loaded successfully


### PR DESCRIPTION
This commit introduces a comprehensive snapshot testing setup using fastlane snapshot for automated screenshot generation across different devices and localizations.

## Changes

### Project Configuration
- Added new `LiveClockSnapshotTests` target for UI testing on iOS 26.0
- Created `LiveClockSnapshot` scheme for running snapshot tests

### UI Accessibility
- Added accessibility identifiers to key UI elements for reliable test automation:
  - Navigation buttons (BackButton)
  - Control buttons (ResetButton, ResumeButton, LapButton, StopButton, StartButton)
  - Views (LapListView)

### Test Implementation
- Implemented snapshot test suite that captures app states:
  - Main screen in stopped state
  - Main screen with running timer and laps
  - Lap list view
  - Landscape orientation

### Fastlane Integration
- Added `take_screenshots` lane for automated screenshot generation
- Configured Snapfile with device and language settings
- Implemented monkey patches to fix iOS 26.0 simulator compatibility issues
- Updated documentation with new lane information

## Testing Coverage
- Devices: iPhone 14 Plus, iPad Pro (12.9-inch)
- Languages: English (en-US) and Japanese (ja)
- Orientations: Portrait and Landscape
