### PR TITLE
Update version to 1.2.0 and refresh platform requirements

### DIFF
--- a/.claude/commands/commit-message.md
+++ b/.claude/commands/commit-message.md
@@ -1,7 +1,10 @@
 Generate commit message in English from git diff.
 
-- First line should be summary of changes.
-- Details follow after a empty line.
-  - Do not quote with code block.
-  - Response without AI signature
-  - Markdown format
+Output ONLY the commit message, with no additional commentary, explanations, or prefixes like "Based on the git diff".
+
+Format requirements:
+- First line: summary of changes
+- Empty line
+- Details in markdown format (no code blocks)
+- No AI signature or metadata
+- No explanatory text before or after the commit message

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Select Xcode
-        run: ls -l /Applications && sudo xcode-select -s /Applications/Xcode_26.app
+        run: ./Scripts/select-xcode.sh
 
       - name: Install tuist
         run: |
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Select Xcode
-        run: ls -l /Applications && sudo xcode-select -s /Applications/Xcode_26.app
+        run: ./Scripts/select-xcode.sh
 
       - name: Run Swift Tests
         run: swift test
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Select Xcode
-        run: ls -l /Applications && sudo xcode-select -s /Applications/Xcode_26.app
+        run: ./Scripts/select-xcode.sh
 
       - name: Install tuist and periphery
         run: |
@@ -140,7 +140,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Select Xcode
-        run: ls -l /Applications && sudo xcode-select -s /Applications/Xcode_26.app
+        run: ./Scripts/select-xcode.sh
 
       - name: Install tuist
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
           fetch-depth: 0
 
       - name: Select Xcode
-        run: ls -l /Applications && sudo xcode-select -s /Applications/Xcode_26.app
+        run: ./Scripts/select-xcode.sh
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/Project.swift
+++ b/Project.swift
@@ -1,6 +1,6 @@
 import ProjectDescription
 
-let version = "1.1.0"
+let version = "1.2.0"
 let copyright = "© LittleApps Inc. All Rights Reserved."
 
 let buildNumber = Environment.buildNumber.getString(default: "0")

--- a/README.md
+++ b/README.md
@@ -27,22 +27,28 @@ A professional-grade timer application designed for stage performances, presenta
 
 | Platform | Minimum Version | Features |
 |----------|----------------|----------|
-| iOS | 17.0+ | Full feature set with display-linked updates |
-| iPadOS | 17.0+ | Optimized for larger screens with multi-column layout |
-| macOS | 14.0+ | Native Mac app with keyboard shortcuts |
-| visionOS | 1.0+ | Spatial computing support with immersive timing |
+| iOS | 18.0+ | Full feature set with display-linked updates |
+| iPadOS | 18.0+ | Optimized for larger screens with multi-column layout |
+| macOS | 15.0+ | Native Mac app with keyboard shortcuts and menu bar extra |
+| visionOS | 2.0+ | Spatial computing support with immersive timing |
 
 ## 🛠️ Development
 
 ### Prerequisites
-- Xcode 15.0 or later
-- macOS Sonoma 14.0 or later
-- [Tuist](https://tuist.io) (recommended) or Swift Package Manager
+- Xcode 16.0 or later
+- Swift 6.0 or later
+- macOS Sequoia 15.0 or later
+- [Tuist](https://tuist.io) for project generation
+- Ruby 3.3 or later (for fastlane and deployment scripts)
 
 ### Building the Project
 
-#### Option A: Using Tuist (Recommended)
+#### Using Tuist
 ```bash
+# Install Tuist (if not already installed)
+brew tap tuist/tuist
+brew install --formula tuist
+
 # Generate Xcode project
 tuist generate
 
@@ -50,10 +56,7 @@ tuist generate
 open LiveClock.xcworkspace
 ```
 
-#### Option B: Using Swift Package Manager
-1. Open `Package.swift` in Xcode
-2. Follow the instructions in `PROJECT_SETUP.md` to configure the app target
-3. Add dependencies to Core, Platform, and UI package products
+**Note**: The project uses Swift Package Manager for dependency management, but Tuist is required for generating the Xcode project with proper configuration. The `Package.swift` defines the library targets (Core, Platform, UI) that the app target depends on.
 
 ### Project Structure
 ```

--- a/Scripts/select-xcode.sh
+++ b/Scripts/select-xcode.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Select Xcode Script
+# Selects the latest stable Xcode version (excluding beta)
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${YELLOW}Selecting latest stable Xcode...${NC}"
+
+# Find the latest stable Xcode version (excluding beta)
+XCODE_PATH=$(ls -d /Applications/Xcode_*.app 2>/dev/null | grep -v beta | sort -V | tail -n 1)
+
+if [ -z "$XCODE_PATH" ]; then
+    echo -e "${RED}No stable Xcode installation found${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}Selected Xcode: $XCODE_PATH${NC}"
+sudo xcode-select -s "$XCODE_PATH"
+
+# Display selected Xcode version
+echo -e "${GREEN}Xcode version:${NC}"
+xcodebuild -version


### PR DESCRIPTION
- Bump version from 1.1.0 to 1.2.0 in Project.swift
- Update minimum platform versions in README:
  - iOS/iPadOS: 17.0+ → 18.0+
  - macOS: 14.0+ → 15.0+ (Sequoia)
  - visionOS: 1.0+ → 2.0+
- Update development prerequisites:
  - Xcode 15.0+ → 16.0+
  - Swift 6.0 requirement added
  - macOS Sonoma 14.0+ → Sequoia 15.0+
  - Ruby 3.3+ requirement documented
- Clarify build process documentation:
  - Emphasize Tuist as the required project generation tool
  - Remove SPM-only build option (Tuist is required)
  - Add Tuist installation instructions
  - Clarify that Package.swift defines library targets used by app
